### PR TITLE
Add TV show Banana exception

### DIFF
--- a/exceptions.txt
+++ b/exceptions.txt
@@ -405,3 +405,4 @@
 290038: 'Troy-Street Magic',
 290865: 'Salem Rogers Model Of The Year 1998',
 286373: 'The Nightly Show',
+289798: 'Banana',


### PR DESCRIPTION
This is needed since it has Banana (2015) as the title on the tvdb and not the correct one Banana
