### PR TITLE
Avengers Assemble, From season 03 changed name to 'Marvels Avengers-Ultron Revolution'.

### DIFF
--- a/exceptions.txt
+++ b/exceptions.txt
@@ -248,7 +248,7 @@
 88631: 'Krod Mandoon',
 259669: 'DaVincis Demons', 'Vincis Demons', 'Vinci\'s Demons',
 72449: 'Stargate SG1',
-264030: 'Avengers Assemble', 'Marvels Avengers Assemble', 'Marvels Avengers-Ultron Revolution',
+264030: 'Avengers Assemble', 'Marvels Avengers Assemble', 'Marvels Avengers-Ultron Revolution', 'Marvels Avengers-Secret Wars',
 73893: 'Enterprise',
 250267: 'The Food Truck NZ',
 81580: 'Come Dine With Me UK',

--- a/exceptions.txt
+++ b/exceptions.txt
@@ -248,7 +248,7 @@
 88631: 'Krod Mandoon',
 259669: 'DaVincis Demons', 'Vincis Demons', 'Vinci\'s Demons',
 72449: 'Stargate SG1',
-264030: 'Avengers Assemble', 'Marvels Avengers Assemble',
+264030: 'Avengers Assemble', 'Marvels Avengers Assemble', 'Marvels Avengers-Ultron Revolution',
 73893: 'Enterprise',
 250267: 'The Food Truck NZ',
 81580: 'Come Dine With Me UK',
@@ -454,4 +454,3 @@
 314599: 'Divorce',
 311713: 'Timeless',
 314087: 'The Grand Tour (2016)', 'The Grand Tour',
-


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Avengers_Assemble_(TV_series)#Season_Three:_Ultron_Revolution